### PR TITLE
Fix HPG chart entrypoint after UV change

### DIFF
--- a/charts/payment-gateway/templates/backend/job/release.yaml
+++ b/charts/payment-gateway/templates/backend/job/release.yaml
@@ -28,7 +28,7 @@ spec:
           command: ["sh"]
           args:
            - -c
-           - "python3 /code/manage.py upgrade"
+           - "django-admin upgrade"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
It was manually deployed to dev using local `helm upgrade` command and appears to work correctly:
```
NAME                                                 READY   STATUS      RESTARTS   AGE
hpg-payment-gateway-backend-77d576cf97-j26gw         1/1     Running     0          23h
hpg-payment-gateway-celery-beat-8645fdb77-spc69      1/1     Running     0          23h
hpg-payment-gateway-celery-flower-6f5c55f497-b8qvn   1/1     Running     0          23h
hpg-payment-gateway-celery-worker-5b4c5d6b7f-6gz8m   1/1     Running     0          23h
hpg-payment-gateway-release-xzczb                    0/1     Completed   0          23h
```