### PR TITLE
Add model download to dedup engine chart

### DIFF
--- a/charts/deduplication-engine/templates/backend/deployment.yaml
+++ b/charts/deduplication-engine/templates/backend/deployment.yaml
@@ -49,5 +49,11 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{ include "keyvault.volumeMounts" . | nindent 12 }}
+            - name: dde-model-data
+              mountPath: /dde-model
       volumes:
         {{ include "keyvault.volumes" . | nindent 8 }}
+        - name: dde-model-data
+          persistentVolumeClaim:
+            claimName: {{ include "deduplication-engine.fullname" . }}-model-data
+            readOnly: true

--- a/charts/deduplication-engine/templates/backend/job/model-downloader.yaml
+++ b/charts/deduplication-engine/templates/backend/job/model-downloader.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}-backend-model-downloader
-          args: ["download_model"]
+          args: ["syncmodels"]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -39,5 +39,4 @@ spec:
         - name: dde-model-data
           persistentVolumeClaim:
             claimName: {{ include "deduplication-engine.fullname" . }}-model-data
-            readOnly: true
   backoffLimit: 3

--- a/charts/deduplication-engine/templates/backend/job/model-downloader.yaml
+++ b/charts/deduplication-engine/templates/backend/job/model-downloader.yaml
@@ -1,24 +1,24 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "deduplication-engine.fullname" . }}-release
+  name: {{ include "deduplication-engine.fullname" . }}-model-downloader
   labels:
     {{- include "deduplication-engine.labels" . | nindent 4 }}
-    deduplication-engine/job: upgrade
+    deduplication-engine/job: model-downloader
   annotations:
     "helm.sh/hook": pre-upgrade, post-install
-    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
     metadata:
       labels:
         {{- include "deduplication-engine.labels" . | nindent 8 }}
-        deduplication-engine/job: upgrade
+        deduplication-engine/job: model-downloader
     spec:
       containers:
-        - name: {{ .Chart.Name }}-backend-release
-          args: ["setup"]
+        - name: {{ .Chart.Name }}-backend-model-downloader
+          args: ["download_model"]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/deduplication-engine/templates/backend/job/model-downloader.yaml
+++ b/charts/deduplication-engine/templates/backend/job/model-downloader.yaml
@@ -31,7 +31,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{ include "keyvault.volumeMounts" . | nindent 12 }}
+            - name: dde-model-data
+              mountPath: /dde-model
       restartPolicy: Never
       volumes:
         {{ include "keyvault.volumes" . | nindent 8 }}
+        - name: dde-model-data
+          persistentVolumeClaim:
+            claimName: {{ include "deduplication-engine.fullname" . }}-model-data
+            readOnly: true
   backoffLimit: 3

--- a/charts/deduplication-engine/templates/backend/pvc.yaml
+++ b/charts/deduplication-engine/templates/backend/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "deduplication-engine.fullname" . }}-model-data
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: azurefile

--- a/charts/deduplication-engine/templates/celery/beat/deployment.yaml
+++ b/charts/deduplication-engine/templates/celery/beat/deployment.yaml
@@ -37,5 +37,11 @@ spec:
                 name: {{ include "deduplication-engine.fullname" . }}-backend
           volumeMounts:
             {{ include "keyvault.volumeMounts" . | nindent 12 }}
+            - name: dde-model-data
+              mountPath: /dde-model
       volumes:
         {{ include "keyvault.volumes" . | nindent 8 }}
+        - name: dde-model-data
+          persistentVolumeClaim:
+            claimName: {{ include "deduplication-engine.fullname" . }}-model-data
+            readOnly: true

--- a/charts/deduplication-engine/templates/celery/worker/deployment.yaml
+++ b/charts/deduplication-engine/templates/celery/worker/deployment.yaml
@@ -42,5 +42,11 @@ spec:
                 name: {{ include "deduplication-engine.fullname" . }}-backend
           volumeMounts:
             {{ include "keyvault.volumeMounts" . | nindent 12 }}
+            - name: dde-model-data
+              mountPath: /dde-model
       volumes:
         {{ include "keyvault.volumes" . | nindent 8 }}
+        - name: dde-model-data
+          persistentVolumeClaim:
+            claimName: {{ include "deduplication-engine.fullname" . }}-model-data
+            readOnly: true


### PR DESCRIPTION
This PR adds:
* Shared volume (RW for downloader, RO for other pods)
* Kubernetes Job (working in same manner as existing release with migrations) that pulls model and writes it to the shared volume