### PR TITLE
Remove HUB env variables from backend

### DIFF
--- a/charts/core/templates/backend/secret.yaml
+++ b/charts/core/templates/backend/secret.yaml
@@ -26,38 +26,6 @@ data:
       5432
       "hopedb" | b64enc | quote
   }}
-  DATABASE_URL_HUB_MIS: {{ printf 
-      "postgis://%s:%s@%s:%d/%s"
-      .Values.postgresql.auth.username
-      .Values.postgresql.auth.password
-      (printf "%s-postgresql" .Release.Name)
-      5432
-      "cash_assist_datahub_mis" | b64enc | quote
-  }}
-  DATABASE_URL_HUB_CA: {{ printf 
-      "postgis://%s:%s@%s:%d/%s"
-      .Values.postgresql.auth.username
-      .Values.postgresql.auth.password
-      (printf "%s-postgresql" .Release.Name)
-      5432
-      "cash_assist_datahub_ca" | b64enc | quote
-  }}
-  DATABASE_URL_HUB_ERP: {{ printf 
-      "postgis://%s:%s@%s:%d/%s"
-      .Values.postgresql.auth.username
-      .Values.postgresql.auth.password
-      (printf "%s-postgresql" .Release.Name)
-      5432
-      "cash_assist_datahub_erp" | b64enc | quote
-  }}
-  DATABASE_URL_HUB_REGISTRATION: {{ printf 
-      "postgis://%s:%s@%s:%d/%s"
-      .Values.postgresql.auth.username
-      .Values.postgresql.auth.password
-      (printf "%s-postgresql" .Release.Name)
-      5432
-      "registration_datahub" | b64enc | quote
-  }}
 {{- end }}
 {{- if .Values.redis.enabled }}
   CELERY_BROKER_URL: {{ printf 


### PR DESCRIPTION
This PR removes the deprecated HUB-related env variables from backend.