### PR TITLE
Add rollme to reporting chart

### DIFF
--- a/charts/reporting/templates/backend/deployment.yaml
+++ b/charts/reporting/templates/backend/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.rollme.enabled }}
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- end }}
       labels:
         {{- include "reporting.selectorLabels" . | nindent 8 }}
         service: "backend"

--- a/charts/reporting/templates/celery/beat/deployment.yaml
+++ b/charts/reporting/templates/celery/beat/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.rollme.enabled }}
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- end }}
       labels:
         {{- include "reporting.selectorLabels" . | nindent 8 }}
         service: "celery-beat"

--- a/charts/reporting/templates/celery/worker/deployment.yaml
+++ b/charts/reporting/templates/celery/worker/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.rollme.enabled }}
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- end }}
       labels:
         {{- include "reporting.selectorLabels" . | nindent 8 }}
         service: "celery-worker"

--- a/charts/reporting/values.yaml
+++ b/charts/reporting/values.yaml
@@ -145,3 +145,6 @@ postgresql:
       scripts:
         init.sql: |
           CREATE EXTENSION IF NOT EXISTS postgis;
+
+rollme:
+  enabled: false


### PR DESCRIPTION
This PR adds the rollme annotation to backend pods, so they're restarted with each helm upgrade.